### PR TITLE
Changed/added generalized Block Cipher Modes of Operation Functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,15 @@ set (Headers
     src/lib.h
     src/aes/aes.h
     src/aes/aesConstants.h
+    src/modes/modes.h
     tools/utils.h
 )
 
 set (Sources
     src/lib.cpp
     src/aes/aes.cpp
+    src/modes/ecb.cpp
+    src/modes/cbc.cpp
     tools/utils.cpp
 )
 

--- a/src/aes/aes.cpp
+++ b/src/aes/aes.cpp
@@ -92,7 +92,7 @@ void AES::encryptBlock(unsigned char* input) {
     // Initialize state with the input block
     unsigned char state[Nb];
     memcpy(state, input, Nb);
-
+    //std::cout << "Encrypting block in AES::encryptBlock!!!" << std::endl;
     // Perform AES encryption rounds
     addRoundKey(state, roundKey);
     size_t round = 1;

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -1,96 +1,30 @@
-// Internal Dependencies
+/*
+ * lib.cpp
+ *
+ * This file contains the implementation of Gestalts security functions.
+ * 
+ * Author: Hunter L, Richardson
+ * Date: 2024-02-24
+ */
+
 #include "lib.h"
-#include "../tools/utils.h"
 
 void Message::aes_encrypt_ecb(std::string key)
 {	
-	size_t msgLen = msg.length();
-	size_t paddedMsgLen = msgLen + 16 - (msgLen % 16);
-	unsigned char* input = new unsigned char[paddedMsgLen];
-	std::memcpy(input, msg.c_str(), msgLen);
-
-	applyPCKS7Padding(input, msgLen, paddedMsgLen);
-	AES aesObject(key);
-
-	for (size_t blockIndex = 0; blockIndex < paddedMsgLen; blockIndex += 16) {
-		aesObject.encryptBlock(input + blockIndex);
-	}
-
-	msg.assign(reinterpret_cast<char*>(input), paddedMsgLen);
-
-	delete[] input;
+	encrypt_ecb<AES>(msg, key, &AES::encryptBlock);
 }
 
 void Message::aes_decrypt_ecb(std::string key)
 {
-	size_t msgLen = msg.length();
-	//size_t paddedMsgLen = ((msgLen - 1) / 16 + 1) * 16;
-	unsigned char* input = new unsigned char[msgLen];
-	std::memcpy(input, msg.c_str(), msgLen);
-
-	AES aesObject(key);
-
-	for (size_t blockIndex = 0; blockIndex < msgLen; blockIndex += 16) {
-		aesObject.decryptBlock(input + blockIndex);
-	}
-
-	size_t origMsgLen = msgLen - static_cast<size_t>(input[msgLen - 1]);
-	removePCKS7Padding(input, origMsgLen, msgLen);
-
-	msg.assign(reinterpret_cast<char*>(input), origMsgLen);
-
-	delete[] input;
+	decrypt_ecb<AES>(msg, key, &AES::decryptBlock);
 }
 
 void Message::aes_encrypt_cbc(std::string key)
 {
-	size_t msgLen = msg.length();
-	size_t paddedMsgLen = msgLen + 16 - (msgLen % 16);
-	unsigned char* input = new unsigned char[paddedMsgLen];
-	std::memcpy(input, msg.c_str(), msgLen);
-	
-	std::string iv = nonce;
-
-	applyPCKS7Padding(input, msgLen, paddedMsgLen);
-
-	AES aesObject(key);
-
-	for (size_t blockIndex = 0; blockIndex < paddedMsgLen; blockIndex += 16) {
-		xorBlock(input, iv, blockIndex);
-		aesObject.encryptBlock(input + blockIndex);
-		iv.assign(reinterpret_cast<char*>(input + blockIndex), 16);
-	}
-
-	msg.assign(reinterpret_cast<char*>(input), paddedMsgLen);
-
-	delete[] input;
+	encrypt_cbc<AES>(msg, key, nonce, &AES::encryptBlock);
 }
 
 void Message::aes_decrypt_cbc(std::string key)
 {
-	size_t msgLen = msg.length();
-	unsigned char* input = new unsigned char[msgLen];
-	std::memcpy(input, msg.c_str(), msgLen);
-
-	std::string iv = nonce;
-	std::string tmp = "";
-
-	AES aesObject(key);
-
-	for (size_t blockIndex = 0; blockIndex < msgLen; blockIndex += 16) {
-		//memcpy(temp, input + blockIndex, 16);
-		tmp.assign(reinterpret_cast<char*>(input + blockIndex), 16);
-		aesObject.decryptBlock(input + blockIndex);
-		xorBlock(input, iv, blockIndex);
-		//memcpy(iv, temp, 16);
-		iv = tmp;
-		//iv.assign(reinterpret_cast<char*>(tmp), 16);
-	}
-
-	size_t origMsgLen = msgLen - static_cast<size_t>(input[msgLen - 1]);
-	removePCKS7Padding(input, origMsgLen, msgLen);
-
-	msg.assign(reinterpret_cast<char*>(input), origMsgLen);
-
-	delete[] input;
+	decrypt_cbc<AES>(msg, key, nonce, &AES::decryptBlock);
 }

--- a/src/lib.h
+++ b/src/lib.h
@@ -1,12 +1,19 @@
+/*
+ * lib.h
+ *
+ * This file contains the definitions of Gestalts security functions, and its central Message structure.
+ * 
+ * Author: Hunter L, Richardson
+ * Date: 2024-02-24
+ */
+
 #pragma once
 
 #include <iostream>
 #include <iomanip>
 #include <string>
 
-// Internal Dependencies
-//#include "DES Source Files/DES.h"
-#include "aes/aes.h"
+#include "modes/modes.h"
 
 enum Algorithm {
 	NONE,

--- a/src/modes/cbc.cpp
+++ b/src/modes/cbc.cpp
@@ -1,0 +1,115 @@
+/*
+ * cbc.cpp
+ *
+ * This file contains the implementation of cbc (Cipher Block Chaining) mode encryption and decryption functions.
+ * It includes functions to encrypt and decrypt data using CBC mode with various block ciphers.
+ * 
+ * References:
+ * - NIST Special Publication SP800-38A: "Recommendation for Block Cipher Modes of Operation" (https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf)
+ * 
+ * Author: Hunter L, Richardson
+ * Date: 2024-02-24
+ */
+
+#include "modes.h"
+
+/*
+ * Cipher Block Chaining (CBC) Encryption In-Place:
+ * 
+ * The Cipher Block Chaining (CBC) mode is a confidentiality mode whose encryption process
+ * features the combining (“chaining”) of the plaintext blocks with the previous ciphertext blocks.
+ * The CBC mode requires an IV to combine with the first plaintext block.
+ *
+ * CBC Encryption:  msg = msg ⊕ iv.
+ * 					msg = encryptBlock(msg  + blockIndex) for blockIndex = 0, 16, ..., n.
+ * 					iv  = msg.
+ *
+ * In CBC encryption, the first input block is formed by exclusive-ORing the first block of the
+ * plaintext with the IV. The forward cipher function is applied to the first input block, and the
+ * resulting output block is the first block of the ciphertext. Each successive plaintext block is
+ * exclusive-ORed with the previous ciphertext block to produce the new input block.
+ * The forward cipher function is applied to each input block to produce the ciphertext block.
+ *
+ * CBC Encryption:
+ *   Input:  Plaintext msg, key K, initialization vector IV
+ *   Output: Ciphertext msg
+ *
+ * In CBC encryption, forward cipher operations cannot be performed in parallel.
+ */
+
+template<typename BlockCipher>
+void encrypt_cbc(std::string& msg, std::string key, std::string iv, function<BlockCipher> encryptBlock)
+{
+    size_t msgLen = msg.length();
+	size_t paddedMsgLen = msgLen + 16 - (msgLen % 16);
+	unsigned char* input = new unsigned char[paddedMsgLen];
+	std::memcpy(input, msg.c_str(), msgLen);
+
+	applyPCKS7Padding(input, msgLen, paddedMsgLen);
+
+	// Create an instance of the block cipher with the provided key
+    BlockCipher cipher(key);
+
+	for (size_t blockIndex = 0; blockIndex < paddedMsgLen; blockIndex += 16) {
+		xorBlock(input, iv, blockIndex);
+		(cipher.*encryptBlock)(input + blockIndex);
+		iv.assign(reinterpret_cast<char*>(input + blockIndex), 16);
+	}
+
+	msg.assign(reinterpret_cast<char*>(input), paddedMsgLen);
+
+	delete[] input;
+}
+
+/*
+ * Cipher Block Chaining (CBC) Decryption In-Place:
+ * 
+ * The Cipher Block Chaining (CBC) mode is a confidentiality mode whose encryption process
+ * features the combining (“chaining”) of the plaintext blocks with the previous ciphertext blocks.
+ * The CBC mode requires an IV to combine with the first plaintext block.
+ *
+ * CBC Decryption:  iv  = msg.
+ * 				 	msg = decryptBlock(msg + blockIndex) ⊕ iv for blockIndex = 0, 16, ..., n.
+ * 					msg = msg ⊕ iv.
+ *
+ * In CBC decryption, the inverse cipher function is applied to the first ciphertext block, and the
+ * resulting output block is exclusive-ORed with the initialization vector to recover the first
+ * plaintext block. Each successive ciphertext block is exclusive-ORed with the previous
+ * ciphertext block to recover the plaintext block.
+ *
+ * CBC Decryption:
+ *   Input:  Ciphertext msg, key K, initialization vector IV
+ *   Output: Plaintext msg
+ *
+ * In CBC decryption, multiple inverse cipher operations can be performed in parallel.
+ */
+
+template<typename BlockCipher>
+void decrypt_cbc(std::string& msg, std::string key, std::string iv, function<BlockCipher> decryptBlock)
+{
+    size_t msgLen = msg.length();
+	unsigned char* input = new unsigned char[msgLen];
+	std::memcpy(input, msg.c_str(), msgLen);
+
+	std::string tmp = "";
+
+	// Create an instance of the block cipher with the provided key
+    BlockCipher cipher(key);
+
+	for (size_t blockIndex = 0; blockIndex < msgLen; blockIndex += 16) {
+		tmp.assign(reinterpret_cast<char*>(input + blockIndex), 16);
+		(cipher.*decryptBlock)(input + blockIndex);
+		xorBlock(input, iv, blockIndex);
+		iv = tmp;
+	}
+
+	size_t origMsgLen = msgLen - static_cast<size_t>(input[msgLen - 1]);
+	removePCKS7Padding(input, origMsgLen, msgLen);
+
+	msg.assign(reinterpret_cast<char*>(input), origMsgLen);
+
+	delete[] input;
+}
+
+template void encrypt_cbc<AES>(std::string&, std::string, std::string, function<AES>);
+template void decrypt_cbc<AES>(std::string&, std::string, std::string, function<AES>);

--- a/src/modes/ecb.cpp
+++ b/src/modes/ecb.cpp
@@ -1,0 +1,100 @@
+/*
+ * ecb.cpp
+ *
+ * This file contains the implementation of ECB (Electronic Codebook) mode encryption and decryption functions.
+ * It includes functions to encrypt and decrypt data using ECB mode with various block ciphers.
+ * 
+ * References:
+ * - NIST Special Publication SP800-38A: "Recommendation for Block Cipher Modes of Operation" (https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf)
+ * 
+ * Author: Hunter L, Richardson
+ * Date: 2024-02-24
+ */
+
+#include "modes.h"
+
+/*
+ * Electronic Codebook (ECB) Encryption In-Place:
+ * 
+ * The Electronic Codebook (ECB) mode is a confidentiality mode that features, for a given key,
+ * the assignment of a fixed ciphertext block to each plaintext block, analogous to the assignment of
+ * code words in a codebook.
+ *
+ * ECB Encryption: msg = encryptBlock(msg + blockIndex) blockIndex = 0, 16, ..., n
+ *
+ * In ECB encryption, the forward cipher function is applied directly and independently to each
+ * block of the plaintext. The resulting sequence of output blocks is the ciphertext.
+ *
+ * ECB Encryption:
+ *   Input:  Plaintext msg, key K
+ *   Output: Ciphertext msg
+ *
+ * In ECB encryption, multiple forward cipher functions can be computed in parallel.
+ */
+template<typename BlockCipher>
+void encrypt_ecb(std::string& msg, std::string key, function<BlockCipher> encryptBlock)
+{
+    size_t msgLen = msg.length();
+    size_t paddedMsgLen = msgLen + 16 - (msgLen % 16);
+    unsigned char* input = new unsigned char[paddedMsgLen];
+    std::memcpy(input, msg.c_str(), msgLen);
+
+    applyPCKS7Padding(input, msgLen, paddedMsgLen);
+
+    // Create an instance of the block cipher with the provided key
+    BlockCipher cipher(key);
+
+    // Encrypt each block using the provided encryption function
+    for (size_t blockIndex = 0; blockIndex < paddedMsgLen; blockIndex += 16) {
+        (cipher.*encryptBlock)(input + blockIndex);
+    }
+
+    // Update the message with the encrypted data
+    msg.assign(reinterpret_cast<char*>(input), paddedMsgLen);
+
+    delete[] input;
+}
+
+/*
+ * Electronic Codebook (ECB) Decryption In-Place:
+ * 
+ * The Electronic Codebook (ECB) mode is a confidentiality mode that features, for a given key,
+ * the assignment of a fixed ciphertext block to each plaintext block, analogous to the assignment of
+ * code words in a codebook.
+ *
+ * ECB Decryption: msg = decryptBlock(msg + blockIndex) for blockIndex = 0, 16, ..., n.
+ *
+ * In ECB decryption, the inverse cipher function is applied directly and independently to each
+ * block of the ciphertext. The resulting sequence of output blocks is the plaintext.
+ *
+ * ECB Decryption:
+ *   Input:  Ciphertext msg, key K
+ *   Output: Plaintext msg
+ *
+ * In ECB decryption, multiple inverse cipher functions can be computed in parallel.
+ */
+template<typename BlockCipher>
+void decrypt_ecb(std::string& msg, std::string key, function<BlockCipher> decryptBlock)
+{
+	size_t msgLen = msg.length();
+	//size_t paddedMsgLen = ((msgLen - 1) / 16 + 1) * 16;
+	unsigned char* input = new unsigned char[msgLen];
+	std::memcpy(input, msg.c_str(), msgLen);
+
+	// Create an instance of the block cipher with the provided key
+    BlockCipher cipher(key);
+
+	for (size_t blockIndex = 0; blockIndex < msgLen; blockIndex += 16) {
+		(cipher.*decryptBlock)(input + blockIndex);
+	}
+
+	size_t origMsgLen = msgLen - static_cast<size_t>(input[msgLen - 1]);
+	removePCKS7Padding(input, origMsgLen, msgLen);
+
+	msg.assign(reinterpret_cast<char*>(input), origMsgLen);
+
+	delete[] input;
+}
+
+template void encrypt_ecb<AES>(std::string&, std::string, function<AES>);
+template void decrypt_ecb<AES>(std::string&, std::string, function<AES>);

--- a/src/modes/modes.h
+++ b/src/modes/modes.h
@@ -1,0 +1,29 @@
+/*
+ * modes.h
+ *
+ * This header file defines functions for various block cipher modes such as ECB and CBC.
+ * It includes function templates for encryption and decryption functions for these modes.
+ * 
+ * Author: Hunter L, Richardson
+ * Date: 2024-02-24
+ */
+
+#pragma once
+
+#include "../../tools/utils.h"
+#include "../aes/aes.h"
+
+#include <string>
+
+template<typename BlockCipher>
+using function = void (BlockCipher::*)(unsigned char*);
+
+template<typename BlockCipher>
+void encrypt_ecb(std::string& msg, std::string key, function<BlockCipher> encryptBlock);
+template<typename BlockCipher>
+void decrypt_ecb(std::string& msg, std::string key, function<BlockCipher> decryptBlock);
+
+template<typename BlockCipher>
+void encrypt_cbc(std::string& msg, std::string key, std::string iv, function<BlockCipher> encryptBlock);
+template<typename BlockCipher>
+void decrypt_cbc(std::string& msg, std::string key, std::string iv, function<BlockCipher> decryptBlock);


### PR DESCRIPTION
### Changes

This PR changes the modes of operations that were block cipher specific and introduces a new set of functions that are generalized for the block cipher modes of operations algorithms specified in [SP 800-38A](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38a.pdf). So now when we add more block ciphers to Gestalt we do not need to duplicate code for their modes of operations, we can use the general ones found in ```src/modes``` folder.

### How it works

Any additional modes of operations should be added as a new file inside ```src/modes``` 

This was made possible by using templates. It was not as straightforward as I assumed it was going to be thanks to how we are trying to be as object-oriented as possible when creating each implementation. 

To improve readability I added a template for the argument in the generalized functions, see below:
```cpp
// modes.h

template<typename BlockCipher>
using function = void (BlockCipher::*)(unsigned char*);

template<typename BlockCipher>
void encrypt_ecb(std::string& msg, std::string key, function<BlockCipher> encryptBlock);
// ...
```

Here is an example of ```encrypt_ecb``` implementation:
```cpp
// modes/ecb.cpp

template<typename BlockCipher>
void encrypt_ecb(std::string& msg, std::string key, function<BlockCipher> encryptBlock)
{
    size_t msgLen = msg.length();
    size_t paddedMsgLen = msgLen + 16 - (msgLen % 16);
    unsigned char* input = new unsigned char[paddedMsgLen];
    std::memcpy(input, msg.c_str(), msgLen);

    applyPCKS7Padding(input, msgLen, paddedMsgLen);

    // Create an instance of the block cipher with the provided key
    BlockCipher cipher(key);

    // Encrypt each block using the provided encryption function
    for (size_t blockIndex = 0; blockIndex < paddedMsgLen; blockIndex += 16) {
        (cipher.*encryptBlock)(input + blockIndex);
    }

    // Update the message with the encrypted data
    msg.assign(reinterpret_cast<char*>(input), paddedMsgLen);

    delete[] input;
}
```

I thought this was a nice solution, keeping much of the present code. But there are other solutions that I explored, but I liked this most. If you have other ideas I am not set in stone on this solution.

### Considerations

Gestalt does not currently have any other block cipher implementations, so when future ones are added small tweaks to these functions may be necessary. But for now, they are all working for AES.

Upon merging into the origin branch, Gestalt will enter a 0.1.1 version change, as the user functions have not been changed, only the underlying code.