### PR TITLE
Add Optional Hash Algorithm to ECDSA Interface (#29)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-Gestalt was designed and developed by Hunter RIchardson.
+Gestalt was designed and developed by Hunter Richardson.
 
 ### Current Maintainers
 
@@ -10,7 +10,6 @@ Gestalt was designed and developed by Hunter RIchardson.
 
 ## Thanks
 
-Special thanks to the following extraordinary individuals, without whom
-Gestalt would not be possible:
+Special thanks to the following extraordinary individuals, without whom Gestalt would not be possible:
 
-*
+* Morteza Mirzaei | mirzaim

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ int main() {
 
 ```cpp
 #include <gestalt/ecdsa.h>
-#include <gestalt/sha2.h>
 #include <iostream>
 
 int main() {
@@ -143,10 +142,9 @@ int main() {
     ECDSA ecdsa(StandardCurve::P256, privateKey);
 
     std::string message = "Hello, Gestalt!";
-    std::string messageHash = hashSHA256(message);
 
-    Signature signature = ecdsa.signMessage(messageHash);
-    bool signatureStatus = ecdsa.verifySignature(messageHash, signature);
+    Signature signature = ecdsa.signMessage(message, HashAlgorithm::SHA256);
+    bool signatureStatus = ecdsa.verifySignature(message, signature, HashAlgorithm::SHA256);
 
     if (signatureStatus) std::cout << "Valid!" << std::endl;
 

--- a/include/gestalt/ecdsa.h
+++ b/include/gestalt/ecdsa.h
@@ -28,6 +28,14 @@
 
 #include "../src/ecc/ecc.h"
 
+enum class HashAlgorithm {
+    SHA1,
+    SHA224,
+    SHA256,
+    SHA384,
+    SHA512
+};
+
 class ECDSA : public ECC {
 private:
 
@@ -35,6 +43,7 @@ private:
     bool isInvalidSignature(Signature S);
 
     Signature generateSignature(const mpz_t& e, mpz_t& k);
+    std::function<std::string(const std::string&)> getHashFunction(HashAlgorithm hashAlg);
 
     friend class ECDSA_Test;
 public:
@@ -47,7 +56,7 @@ public:
 
 	~ECDSA() {}
 
-    Signature signMessage(const std::string& messageHash);
-    Signature signMessage(const std::string& messageHash, BigInt& K);
-    bool verifySignature(const std::string& messageHash, const Signature signature);
+    Signature signMessage(const std::string& message, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
+    Signature signMessage(const std::string& message, BigInt& K, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
+    bool verifySignature(const std::string& message, const Signature& signature, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
 };

--- a/include/gestalt/ecdsa.h
+++ b/include/gestalt/ecdsa.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <functional>
 #include "../src/ecc/ecc.h"
 
 enum class HashAlgorithm {

--- a/include/gestalt/ecdsa.h
+++ b/include/gestalt/ecdsa.h
@@ -29,6 +29,7 @@
 #include "../src/ecc/ecc.h"
 
 enum class HashAlgorithm {
+    None,   // No hash function
     SHA1,
     SHA224,
     SHA256,
@@ -56,7 +57,7 @@ public:
 
 	~ECDSA() {}
 
-    Signature signMessage(const std::string& message, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
-    Signature signMessage(const std::string& message, BigInt& K, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
-    bool verifySignature(const std::string& message, const Signature& signature, HashAlgorithm hashAlg = HashAlgorithm::SHA256);
+    Signature signMessage(const std::string& message, HashAlgorithm hashAlg = HashAlgorithm::None);
+    Signature signMessage(const std::string& message, BigInt& K, HashAlgorithm hashAlg = HashAlgorithm::None);
+    bool verifySignature(const std::string& message, const Signature& signature, HashAlgorithm hashAlg = HashAlgorithm::None);
 };

--- a/src/ecc/ecdsa/ecdsa.cpp
+++ b/src/ecc/ecdsa/ecdsa.cpp
@@ -31,6 +31,8 @@
 
 std::function<std::string(const std::string&)> ECDSA::getHashFunction(HashAlgorithm hashAlg) {
     switch (hashAlg) {
+        case HashAlgorithm::None:
+            return [](const std::string& in) { return in; };
         case HashAlgorithm::SHA1:
             return hashSHA1;
         case HashAlgorithm::SHA224:


### PR DESCRIPTION
This PR addresses Issue #29 by adding an optional HashAlgorithm parameter to ECDSA's signMessage and verifySignature methods. The update maintains backward compatibility, passing all existing tests without modification.