### PR TITLE
Adds documentation for 0.6.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,14 @@ Gestalt Releases
  Gestalt 0.6
 -----------
 
+### Changes between 0.6.1 and 0.6.2 [3 Nov 2024]
+
+ * Adds `peerPublicKey` as parameter for ECDSA signature verification
+ * Adds `ECDSAPublicKey` and `ECDHPublicKey` to be used for ECC public keys in place of old `Point` class
+ * Adds `HashAlgorithm` enum as parameter to ECDSA signature generation/ verification to select hash to be used
+ * Refactors ECDH to force user to pass `ECDHPublicKey` as parameter to compute shared secret for simplicity
+ * Implements CI/CD GitHub action workflow to run unit tests on push/PR to main or release branches
+
 ### Changes between 0.6 and 0.6.1 [8 Aug 2024]
 
  * Refactors unit tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16.3)
 
 # Project setup
-project (Gestalt VERSION 0.6.1 LANGUAGES C CXX)
+project (Gestalt VERSION 0.6.2 LANGUAGES C CXX)
 set (CMAKE_C_STANDARD 99)
 set (CMAKE_CXX_STANDARD 11)
 set (CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
I seem to have forgot to push the changed I made to the documentation in `CHANGES` and the `CMakeLists.txt` in the original PR for 0.6.2, this PR will add that documentation.