### PR TITLE
Adds ability to import and export compressed ECC public keys

### DIFF
--- a/src/aes/aesCore.cpp
+++ b/src/aes/aesCore.cpp
@@ -45,6 +45,7 @@
 
 #include <sstream>
 #include <cstring>
+#include <cstdint>
 
 #include "aesCore.h"
 #include "aesConstants.h"

--- a/src/ecc/eccObjects.h
+++ b/src/ecc/eccObjects.h
@@ -12,7 +12,10 @@
  */
 #pragma once
 
+#include <string>
+
 #include "bigInt/bigInt.h"
+#include "utils.h"
 
 class Point {
 public:
@@ -28,6 +31,12 @@ public:
     Point(const Point& other) {
         mpz_init_set(x, other.x);
         mpz_init_set(y, other.y);
+    }
+
+    Point(const mpz_t xVal, const mpz_t yVal) {
+        mpz_inits(x, y, NULL);
+        mpz_set(x, xVal);
+        mpz_set(y, yVal);
     }
 
     void operator =(const Point& other) {
@@ -63,11 +72,35 @@ private:
         }
     }
 
+    bool modular_sqrt(const mpz_t n, const mpz_t p, mpz_t result) {
+        // Only works if p ≡ 3 mod 4
+        if (mpz_congruent_ui_p(p, 3, 4)) {
+            mpz_t exp;
+            mpz_init(exp);
+            mpz_add_ui(exp, p, 1);
+            mpz_fdiv_q_ui(exp, exp, 4);
+            mpz_powm(result, n, exp, p);
+            mpz_clear(exp);
+
+            // Check if result^2 ≡ n mod p
+            mpz_t check;
+            mpz_init(check);
+            mpz_powm_ui(check, result, 2, p);
+            bool isValid = (mpz_cmp(check, n) == 0);
+            mpz_clear(check);
+            return isValid;
+        }
+        return false;  // For full generality, implement Tonelli-Shanks
+    }
+
 public:
     // Constructors
     PublicKey() : curve(StandardCurve::P256) {}
     PublicKey(const std::string& strX, const std::string& strY) : point(Point(strX, strY)) {
         curve = guessCurve(point);
+    }
+    PublicKey(const std::string& compressedPublicKey, const StandardCurve& curve) : curve(curve) {
+        importCompressed(compressedPublicKey);
     }
     PublicKey(const Point& publicKey) : point(publicKey) {
         curve = guessCurve(publicKey);
@@ -79,12 +112,67 @@ public:
     StandardCurve getPublicKeyCurve() const { return curve; }
 
     void setCurve(const StandardCurve& givenCurve) { curve = givenCurve; }
+
+    std::string exportCompressed() const {
+        std::string result;
+        mpz_t yMod2;
+        mpz_init(yMod2);
+        mpz_mod_ui(yMod2, point.y, 2);
+        result += (mpz_cmp_ui(yMod2, 0) == 0) ? '\x02' : '\x03';
+
+        // Serialize x
+        size_t count = (mpz_sizeinbase(point.x, 2) + 7) / 8;
+        result.resize(1 + count);
+        mpz_export(&result[1], nullptr, 1, 1, 1, 0, point.x);
+        mpz_clear(yMod2);
+        return bytesToHex(result);
+    }
+
+    void importCompressed(const std::string& compressedHexKey) {
+        if (compressedHexKey.length() < 4 || compressedHexKey.length() % 2 != 0) {
+            throw std::invalid_argument("Invalid hex-encoded compressed key");
+        }
+
+        // Check the compression byte (first 2 hex characters)
+        std::string compressionByte = compressedHexKey.substr(0, 2);
+        if (compressionByte != "02" && compressionByte != "03") {
+            throw std::invalid_argument("Invalid compressed ECC key format");
+        }
+
+        Curve curve = getCurveParams(this->curve);
+        mpz_t x, y, rhs;
+        mpz_inits(x, y, rhs, nullptr);
+
+        // Extract x coordinate (skip first 2 hex characters)
+        std::string xCoordHex = compressedHexKey.substr(2);
+        mpz_set_str(x, xCoordHex.c_str(), 16);
+
+        // Calculate y^2 = x^3 + ax + b mod p
+        mpz_powm_ui(rhs, x, 3, curve.p);
+        mpz_addmul(rhs, curve.a, x);
+        mpz_add(rhs, rhs, curve.b);
+        mpz_mod(rhs, rhs, curve.p);
+
+        bool found = modular_sqrt(rhs, curve.p, y);
+        if (!found) throw std::runtime_error("Failed to compute sqrt for compressed key");
+
+        // Check compression byte to determine which y to use
+        bool isOddCompression = (compressionByte == "03");
+        if ((isOddCompression && mpz_even_p(y)) || (!isOddCompression && mpz_odd_p(y))) {
+            mpz_sub(y, curve.p, y);
+        }
+
+        point = Point(x, y);
+        mpz_clears(x, y, rhs, nullptr);
+    }
+
 };
 
 class ECDSAPublicKey : public PublicKey{
 public:
     ECDSAPublicKey() : PublicKey() {}
     ECDSAPublicKey(const std::string& strX, const std::string& strY) : PublicKey(strX, strY) {}
+    ECDSAPublicKey(const std::string& compressedPublicKey, const StandardCurve& curve) : PublicKey(compressedPublicKey, curve) {}
     ECDSAPublicKey(const Point& point) : PublicKey(point) {}
     ECDSAPublicKey(const Point& point, const StandardCurve& curve) : PublicKey(point, curve) {}
 };
@@ -93,6 +181,7 @@ class ECDHPublicKey : public PublicKey{
 public:
     ECDHPublicKey() : PublicKey() {}
     ECDHPublicKey(const std::string& strX, const std::string& strY) : PublicKey(strX, strY) {}
+    ECDHPublicKey(const std::string& compressedPublicKey, const StandardCurve& curve) : PublicKey(compressedPublicKey, curve) {}
     ECDHPublicKey(const Point& point) : PublicKey(point) {}
     ECDHPublicKey(const Point& point, const StandardCurve& curve) : PublicKey(point, curve) {}
 };

--- a/src/hmac/hmac.h
+++ b/src/hmac/hmac.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 typedef std::string (*hash_f)(const std::string& in);
 

--- a/src/sha1/sha1Core.h
+++ b/src/sha1/sha1Core.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 class SHA1 {
 private:

--- a/src/sha2/sha2.cpp
+++ b/src/sha2/sha2.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <iomanip>
 #include <climits>
+#include <cstdint>
 
 #include <gestalt/sha2.h>
 #include "sha2Constants.h"

--- a/tests/ecc/test_ecc_functions.cpp
+++ b/tests/ecc/test_ecc_functions.cpp
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 
 #include "ecc/ecc.h"
+#include "utils.h"
 
 class ECC_Test : public ::testing::Test {
 private:
@@ -185,6 +186,27 @@ TEST_F(ECC_Test, setKeyPair) {
     EXPECT_THROW(eccObject.setKeyPair(mismatchKeyPair), std::invalid_argument);
 
     EXPECT_TRUE(true);
+}
+
+TEST_F(ECC_Test, ExportImportCompressedPublicKey) {
+    // Known valid public key
+    std::string uncompressedX = "0xCEC028EE08D09E02672A68310814354F9EABFFF0DE6DACC1CD3A774496076AE";
+    std::string uncompressedY = "0xEFF471FBA0409897B6A48E8801AD12F95D0009B753CF8F51C128BF6B0BD27FBD";
+
+    ECDSAPublicKey originalKey(uncompressedX, uncompressedY);
+
+    // Export to compressed format
+    std::string compressed = originalKey.exportCompressed();
+
+    // Import the compressed key into a new object
+    ECDSAPublicKey importedKey(compressed, StandardCurve::secp256k1);
+
+    // Compare x and y of the original and imported key
+    Point orig = originalKey.getPublicKey();
+    Point imp = importedKey.getPublicKey();
+
+    EXPECT_EQ(mpz_cmp(orig.x, imp.x), 0);
+    EXPECT_EQ(mpz_cmp(orig.y, imp.y), 0);
 }
 
 TEST(ECC_Objects, BigIntInitialization) {

--- a/tools/utils.h
+++ b/tools/utils.h
@@ -16,6 +16,7 @@
 
 #include <vector>
 #include <string>
+#include <cstdint>
 
 /*
  * TODO: these following 9 functions was my first attempt to streamline parsing user inputs.


### PR DESCRIPTION
#### Issues encorporated:
- [44 Support importing and exporting compressed ECC public keys](https://github.com/HLRichardson-Git/Gestalt/issues/44)

### Description of changes:

This PR adds the ability for users to import and export ECC Public Keys in the compressed format.

1. ECDSA Interface Updates

    - Added contructor for both `ECDSAPublicKey` and `ECDHPublicKey` that takes the compressed key and the keys curve, and will automatically decompress it.
    - Added public `importCompressed` and `exportCompressed` to parent class `PublicKey` so that `ECDSAPublicKey` and `ECDHPublicKey` can both use it. Users can also use it as a function.

### Release notes:

 * Adds ability to import and export compressed ECC public keys